### PR TITLE
Shrunk printf

### DIFF
--- a/main.h
+++ b/main.h
@@ -8,7 +8,7 @@ char *_strcpy(char *dest, char *src);
 char *append(char *str, char c);
 int _puts(char *str);
 int _putchar(char c);
-char *_memset(char *str, int bval);
+char *_memset(char *adr, int bval);
 int fmt(char c, va_list args);
 
 #endif

--- a/main.h
+++ b/main.h
@@ -1,5 +1,6 @@
 #ifndef MAIN_H_
 #define MAIN_H_
+#include <stdarg.h>
 int _printf(const char *format, ...);
 int _contains(const char *str, char c);
 int _strlen(const char *str);
@@ -7,6 +8,7 @@ char *_strcpy(char *dest, char *src);
 char *append(char *str, char c);
 int _puts(char *str);
 int _putchar(char c);
-char* _memset(char *str, int bval);
+char *_memset(char *str, int bval);
+int fmt(char c, va_list args);
 
 #endif

--- a/memset.c
+++ b/memset.c
@@ -4,19 +4,19 @@
  * _memset - sets values of bytes to specific value
  *
  * @adr: head address
- * @n: number of bytes
+ * @bval: number of bytes
  *
  * Return: pointer to place
  */
 
-char* _memset(char *str, int bval)
+char *_memset(char *adr, int bval)
 {
 	int i;
 
-	for (i = 0; i < _strlen(str); i++)
+	for (i = 0; i < _strlen(adr); i++)
 	{
-		*(str + i) = bval;
+		*(adr + i) = bval;
 	}
 
-	return (str);
+	return (adr);
 }

--- a/printf.c
+++ b/printf.c
@@ -14,8 +14,8 @@ int _printf(const char *format, ...)
 	va_list args;
 
 	va_start(args, format);
-	buff_size = _strlen(format) - _contains(format , '%');
-	buffer = (char *) malloc(_strlen(format) - _contains(format,'%')); /* sized of the non % instances only*/
+	buff_size = _strlen(format) - _contains(format, '%');
+	buffer = (char *) malloc(buff_size); /* sized of the non % instances only*/
 
 	if (!format && !buffer) /* No string. No laundry */
 		return (0);

--- a/printf.c
+++ b/printf.c
@@ -19,7 +19,7 @@ int _printf(const char *format, ...)
 
 	identifiers = _contains(format, '%'); /* instances of %s, %c etc */
 	BUFF_SIZE = _strlen(format) - identifiers;
-	buffer = malloc(BUFF_SIZE); /* sized of the non % instances only*/
+	buffer = (char *) malloc(BUFF_SIZE); /* sized of the non % instances only*/
 	if (!buffer)
 		return (-1);
 
@@ -35,8 +35,8 @@ int _printf(const char *format, ...)
 			if (buffer) /* printing and clearing buffer on formatted things */
 			{
 				printed += _puts(buffer);
-				free(buffer);
-				buffer =  malloc(BUFF_SIZE);
+				_memset(buffer, 0);
+				buffer = (char *) malloc(BUFF_SIZE);
 				if (!buffer)
 					return (-1);
 				buff_idx = 0;

--- a/printf.c
+++ b/printf.c
@@ -36,7 +36,7 @@ int _printf(const char *format, ...)
 				buff_idx = 0;
 			}
 			printed += fmt(*(format + fmt_idx + 1), args);
-				fmt_idx += 2;
+			fmt_idx += 2;
 		}
 		else
 			*(buffer + buff_idx++) = *(format + fmt_idx++); /* filling up buffer */

--- a/printf.c
+++ b/printf.c
@@ -40,7 +40,7 @@ int _printf(const char *format, ...)
 					return (-1);
 				buff_idx = 0;
 			}
-			printed += fmt(*(format + fmt_idx + 1));
+			printed += fmt(*(format + fmt_idx + 1), args);
 				fmt_idx += 2;
 		}
 		else

--- a/printf.c
+++ b/printf.c
@@ -9,22 +9,16 @@
  **/
 int _printf(const char *format, ...)
 {
-	int buff_idx, fmt_idx; /* Indexes */
-	unsigned int identifiers, BUFF_SIZE, printed;
+	unsigned int buff_idx, fmt_idx, printed;
 	char *buffer; /*where non formated things are stored*/
 	va_list args;
 
-	va_start(args, format);
-
-	identifiers = _contains(format, '%'); /* instances of %s, %c etc */
-	BUFF_SIZE = _strlen(format) - identifiers;
-	buffer = (char *) malloc(BUFF_SIZE); /* sized of the non % instances only*/
-
 	if (!format && !buffer) /* No string. No laundry */
 		return (0);
+	va_start(args, format);
 
-	buff_idx = fmt_idx = 0; /*chain assignment*/
-	printed = 0; /*this alone due to diff type*/
+	buffer = (char *) malloc(_strlen(format) - _contains(format,'%')); /* sized of the non % instances only*/
+	buff_idx = fmt_idx = printed = 0; /*chain assignment*/
 	while (*(format + fmt_idx))
 	{
 		if ((*(format + fmt_idx) == '%') && (*(format + fmt_idx + 1)))

--- a/printf.c
+++ b/printf.c
@@ -1,5 +1,4 @@
 #include "main.h"
-#include <stdarg.h>
 #include <stdlib.h>
 #include <unistd.h>
 /**
@@ -41,18 +40,7 @@ int _printf(const char *format, ...)
 					return (-1);
 				buff_idx = 0;
 			}
-			switch (*(format + fmt_idx + 1)) /*this needs to shrink*/
-			{
-				case 's':
-					printed += _puts(va_arg(args, char*));
-					break;
-				case 'c':
-					printed += _putchar(va_arg(args, int));
-					break;
-				case '%': /*add 1 byte*/
-					printed += _putchar('%');
-					break;
-			}
+			printed += fmt(*(format + fmt_idx + 1));
 				fmt_idx += 2;
 		}
 		else
@@ -68,4 +56,20 @@ int _printf(const char *format, ...)
 		free(buffer);
 	}
 		return (printed);
+}
+int fmt(char c, va_list args)
+{
+	switch (c) /*this needs to shrink*/
+	{
+		case 's':
+			return(_puts(va_arg(args, char*)));
+			break;
+		case 'c':
+			return (_putchar(va_arg(args, int)));
+			break;
+		case '%': /*add 1 byte*/
+			return (_putchar('%'));
+			break;
+	}
+
 }

--- a/printf.c
+++ b/printf.c
@@ -20,6 +20,8 @@ int _printf(const char *format, ...)
 	identifiers = _contains(format, '%'); /* instances of %s, %c etc */
 	BUFF_SIZE = _strlen(format) - identifiers;
 	buffer = malloc(BUFF_SIZE); /* sized of the non % instances only*/
+	if (!buffer)
+		return (-1);
 
 	if (!format) /* No string. No laundry */
 		return (0);
@@ -31,11 +33,9 @@ int _printf(const char *format, ...)
 	{
 		if ((*(format + fmt_idx) == '%') && (*(format + fmt_idx + 1)))
 		{
-			if (*buffer) /* printing and clearing buffer on formatted things */
+			if (buffer) /* printing and clearing buffer on formatted things */
 			{
-				_puts(buffer);
-				BUFF_SIZE -= _strlen(buffer);
-				printed += _strlen(buffer);
+				printed += _puts(buffer);
 				free(buffer);
 				buffer =  malloc(BUFF_SIZE);
 				if (!buffer)

--- a/printf.c
+++ b/printf.c
@@ -26,9 +26,8 @@ int _printf(const char *format, ...)
 	if (!format) /* No string. No laundry */
 		return (0);
 
-	buff_idx = 0; /* was there a way to squish these together? */
-	fmt_idx = 0;
-	printed = 0;
+	buff_idx = fmt_idx = 0; /*chain assignment*/
+	printed = 0; /*this alone due to diff type*/
 	while (*(format + fmt_idx))
 	{
 		if ((*(format + fmt_idx) == '%') && (*(format + fmt_idx + 1)))
@@ -63,10 +62,10 @@ int _printf(const char *format, ...)
 			fmt_idx++;
 		}
 	}
-	if (buffer) /*final buffer check*/
+	if (buffer)
 	{
-		printed += _puts(buffer);
+		_puts(buffer);
 		free(buffer);
 	}
-	return (printed);
+		return (printed);
 }

--- a/printf.c
+++ b/printf.c
@@ -70,6 +70,8 @@ int fmt(char c, va_list args)
 		case '%': /*add 1 byte*/
 			return (_putchar('%'));
 			break;
+		default:
+			return (0);
 	}
 
 }

--- a/printf.c
+++ b/printf.c
@@ -38,6 +38,8 @@ int _printf(const char *format, ...)
 				printed += _strlen(buffer);
 				free(buffer);
 				buffer =  malloc(BUFF_SIZE);
+				if (!buffer)
+					return (-1);
 				buff_idx = 0;
 			}
 			switch (*(format + fmt_idx + 1)) /*this needs to shrink*/
@@ -61,7 +63,7 @@ int _printf(const char *format, ...)
 			fmt_idx++;
 		}
 	}
-	if (*buffer) /*final buffer check*/
+	if (buffer) /*final buffer check*/
 	{
 		printed += _puts(buffer);
 		free(buffer);

--- a/printf.c
+++ b/printf.c
@@ -9,15 +9,17 @@
  **/
 int _printf(const char *format, ...)
 {
-	unsigned int buff_idx, fmt_idx, printed;
+	unsigned int buff_idx, fmt_idx, buff_size, printed;
 	char *buffer; /*where non formated things are stored*/
 	va_list args;
 
+	va_start(args, format);
+	buff_size = _strlen(format) - _contains(format , '%');
+	buffer = (char *) malloc(_strlen(format) - _contains(format,'%')); /* sized of the non % instances only*/
+
 	if (!format && !buffer) /* No string. No laundry */
 		return (0);
-	va_start(args, format);
 
-	buffer = (char *) malloc(_strlen(format) - _contains(format,'%')); /* sized of the non % instances only*/
 	buff_idx = fmt_idx = printed = 0; /*chain assignment*/
 	while (*(format + fmt_idx))
 	{
@@ -26,7 +28,11 @@ int _printf(const char *format, ...)
 			if (buffer) /* printing and clearing buffer on formatted things */
 			{
 				printed += _puts(buffer);
+				buff_size -= _strlen(buffer);
 				_memset(buffer, 0);
+				buffer = (char *) malloc(buff_size);
+				if (!buffer)
+					return (-1);
 				buff_idx = 0;
 			}
 			printed += fmt(*(format + fmt_idx + 1), args);

--- a/printf.c
+++ b/printf.c
@@ -19,10 +19,8 @@ int _printf(const char *format, ...)
 	identifiers = _contains(format, '%'); /* instances of %s, %c etc */
 	BUFF_SIZE = _strlen(format) - identifiers;
 	buffer = (char *) malloc(BUFF_SIZE); /* sized of the non % instances only*/
-	if (!buffer)
-		return (-1);
 
-	if (!format) /* No string. No laundry */
+	if (!format && !buffer) /* No string. No laundry */
 		return (0);
 
 	buff_idx = fmt_idx = 0; /*chain assignment*/
@@ -44,11 +42,7 @@ int _printf(const char *format, ...)
 				fmt_idx += 2;
 		}
 		else
-		{
-			*(buffer + buff_idx) = *(format + fmt_idx); /* filling up buffer */
-			buff_idx++;
-			fmt_idx++;
-		}
+			*(buffer + buff_idx++) = *(format + fmt_idx++); /* filling up buffer */
 	}
 	if (buffer)
 	{
@@ -62,7 +56,7 @@ int fmt(char c, va_list args)
 	switch (c) /*this needs to shrink*/
 	{
 		case 's':
-			return(_puts(va_arg(args, char*)));
+			return (_puts(va_arg(args, char*)));
 			break;
 		case 'c':
 			return (_putchar(va_arg(args, int)));

--- a/printf.c
+++ b/printf.c
@@ -33,9 +33,6 @@ int _printf(const char *format, ...)
 			{
 				printed += _puts(buffer);
 				_memset(buffer, 0);
-				buffer = (char *) malloc(BUFF_SIZE);
-				if (!buffer)
-					return (-1);
 				buff_idx = 0;
 			}
 			printed += fmt(*(format + fmt_idx + 1), args);
@@ -51,19 +48,22 @@ int _printf(const char *format, ...)
 	}
 		return (printed);
 }
+/**
+ * fmt - format because its too chonky for printf
+ * @c: format character (for now)
+ * @args: the arguments to pop from
+ * Return: bytes written to stdout
+ */
 int fmt(char c, va_list args)
 {
 	switch (c) /*this needs to shrink*/
 	{
 		case 's':
 			return (_puts(va_arg(args, char*)));
-			break;
 		case 'c':
 			return (_putchar(va_arg(args, int)));
-			break;
 		case '%': /*add 1 byte*/
 			return (_putchar('%'));
-			break;
 		default:
 			return (0);
 	}

--- a/tests/char_print.c
+++ b/tests/char_print.c
@@ -10,6 +10,6 @@ int main(void)
 {
 	char c = 97;
 
-	_printf("cat: %css\n", c);
+	_printf("cat: %css\noh wait is that...a %%\n", c);
 	return (0);
 }


### PR DESCRIPTION
# Fixes
1. free is evil sometimes
2. printf is now less than 40 lines
3. cleared up a lot of boiler plate variables
# Features
1. switch case now became its own fmt function
2. more test cases added
3. %% is now handled